### PR TITLE
Fix "missing translation" error

### DIFF
--- a/app/components/ens/constants.js
+++ b/app/components/ens/constants.js
@@ -1,4 +1,0 @@
-import lang from 'i18n-js';
-
-export const YOUR_CONTACT_CODE = lang.t('constants.contact_code');
-export const YOUR_WALLET_ADDRESS = lang.t('constants.wallet_address');

--- a/app/components/ens/nameLookup.js
+++ b/app/components/ens/nameLookup.js
@@ -30,7 +30,6 @@ import NotInterested from '@material-ui/icons/NotInterested';
 import Face from '@material-ui/icons/Face';
 import IDNANormalizer from 'idna-normalize';
 import { nullAddress, getResolver } from './utils/domain';
-import { YOUR_CONTACT_CODE } from './constants';
 import DisplayBox from './DisplayBox';
 import styled from "styled-components";
 import { Route } from "react-router-dom";
@@ -104,7 +103,7 @@ const MobileAddressDisplay = ({ domainName, address, statusAccount, expirationTi
                preRegisteredCallback={onSubmit}
                registeredCallbackFn={console.log} />}
     {!edit && <DisplayBox displayType='Your wallet address' text={address} />}
-    {!edit && validStatusAddress(statusAccount) && <DisplayBox displayType={YOUR_CONTACT_CODE} text={statusAccount} />}
+    {!edit && validStatusAddress(statusAccount) && <DisplayBox displayType={lang.t('constants.contact_code')} text={statusAccount} />}
   </Fragment>
 )
 

--- a/app/components/ens/registerSubDomain.js
+++ b/app/components/ens/registerSubDomain.js
@@ -19,7 +19,6 @@ import Terms from './terms';
 import {generateXY} from '../../utils/ecdsa';
 import {getResolver} from './utils/domain';
 import DisplayBox from './DisplayBox';
-import { YOUR_CONTACT_CODE, YOUR_WALLET_ADDRESS } from './constants';
 import {checkAndDispatchStatusContactCode} from "../../actions/accounts";
 
 const { soliditySha3, fromWei } = web3.utils;
@@ -140,27 +139,27 @@ class InnerForm extends React.Component {
           <Hidden mdUp>
 
             {!editAccount ? <Fragment>
-              <DisplayBox displayType={YOUR_WALLET_ADDRESS}
+              <DisplayBox displayType={lang.t('constants.wallet_address')}
                 text={values.address}/>
 
-              <DisplayBox displayType={YOUR_CONTACT_CODE}
+              <DisplayBox displayType={lang.t('constants.contact_code')}
                 text={statusContactCode}
                 showBlueBox={!statusContactCode}
                 onClick={() => requestStatusContactCode()}/>
             </Fragment> :
             <Fragment>
-              <Field label={YOUR_WALLET_ADDRESS}>
+              <Field label={lang.t('constants.wallet_address')}>
                 <MobileSearch
                   name="address"
                   style={{ marginTop: '10px' }}
-                  placeholder={YOUR_WALLET_ADDRESS}
+                  placeholder={lang.t('constants.wallet_address')}
                   value={values.address}
                   onChange={handleChange}
                   onClick={() => setFieldValue('address', '')}
                   required
                   wide />
               </Field>
-              <Field label={YOUR_CONTACT_CODE}>
+              <Field label={lang.t('constants.contact_code')}>
                 <MobileSearch
                   name="statusAddress"
                   style={{ marginTop: '10px' }}


### PR DESCRIPTION
The loading of the file constants.js was being done before the languages were loaded, as the file shown to be not necessary anymore as those constants are defined in the language system, removed the file and loaded them directly from languages.

They are in a different section of languages as this is a common string to be reused. 