### PR TITLE
Externalize slash mechanism

### DIFF
--- a/contracts/mocks/Dummy2SlashMechanism.sol
+++ b/contracts/mocks/Dummy2SlashMechanism.sol
@@ -9,7 +9,7 @@ contract Dummy2SlashMechanism is SlashMechanism {
 
     constructor(
         uint256 _usernameMinLength,
-        bytes32 _reservedUsernamesMerkleRoot,
+        bytes32 _reservedUsernamesMerkleRoot
     )
         public 
         SlashMechanism(

--- a/contracts/mocks/Dummy2SlashMechanism.sol
+++ b/contracts/mocks/Dummy2SlashMechanism.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: CC0-1.0
+
+pragma solidity 0.5.11;
+
+import "../registry/SlashMechanism.sol";
+
+
+contract Dummy2SlashMechanism is SlashMechanism {
+
+    constructor(
+        uint256 _usernameMinLength,
+        bytes32 _reservedUsernamesMerkleRoot,
+    )
+        public 
+        SlashMechanism(
+            _usernameMinLength,
+            _reservedUsernamesMerkleRoot
+        ) 
+    {
+
+    }
+} 

--- a/contracts/mocks/Dummy2UsernameRegistrar.sol
+++ b/contracts/mocks/Dummy2UsernameRegistrar.sol
@@ -11,8 +11,7 @@ contract Dummy2UsernameRegistrar is UsernameRegistrar {
         ENS _ensRegistry,
         PublicResolver _resolver,
         bytes32 _ensNode,
-        uint256 _usernameMinLength,
-        bytes32 _reservedUsernamesMerkleRoot,
+        address _slashMechanism,
         address _parentRegistry
     )
         public
@@ -21,8 +20,7 @@ contract Dummy2UsernameRegistrar is UsernameRegistrar {
             _ensRegistry,
             _resolver,
             _ensNode,
-            _usernameMinLength,
-            _reservedUsernamesMerkleRoot,
+            _slashMechanism,
             _parentRegistry
         )
     {

--- a/contracts/mocks/DummyUsernameRegistrar.sol
+++ b/contracts/mocks/DummyUsernameRegistrar.sol
@@ -11,8 +11,7 @@ contract DummyUsernameRegistrar is UsernameRegistrar {
         ENS _ensRegistry,
         PublicResolver _resolver,
         bytes32 _ensNode,
-        uint256 _usernameMinLength,
-        bytes32 _reservedUsernamesMerkleRoot,
+        address _slashMechanism,
         address _parentRegistry
     )
         public
@@ -21,8 +20,7 @@ contract DummyUsernameRegistrar is UsernameRegistrar {
             _ensRegistry,
             _resolver,
             _ensNode,
-            _usernameMinLength,
-            _reservedUsernamesMerkleRoot,
+            _slashMechanism,
             _parentRegistry
         )
     {

--- a/contracts/mocks/UpdatedDummy2UsernameRegistrar.sol
+++ b/contracts/mocks/UpdatedDummy2UsernameRegistrar.sol
@@ -15,7 +15,7 @@ contract UpdatedDummy2UsernameRegistrar is Dummy2UsernameRegistrar {
         address _parentRegistry
     )
         public
-        UsernameRegistrar(
+        Dummy2UsernameRegistrar(
             _token,
             _ensRegistry,
             _resolver,

--- a/contracts/mocks/UpdatedDummy2UsernameRegistrar.sol
+++ b/contracts/mocks/UpdatedDummy2UsernameRegistrar.sol
@@ -11,18 +11,16 @@ contract UpdatedDummy2UsernameRegistrar is Dummy2UsernameRegistrar {
         ENS _ensRegistry,
         PublicResolver _resolver,
         bytes32 _ensNode,
-        uint256 _usernameMinLength,
-        bytes32 _reservedUsernamesMerkleRoot,
+        address _slashMechanism,
         address _parentRegistry
     )
         public
-        Dummy2UsernameRegistrar(
+        UsernameRegistrar(
             _token,
             _ensRegistry,
             _resolver,
             _ensNode,
-            _usernameMinLength,
-            _reservedUsernamesMerkleRoot,
+            _slashMechanism,
             _parentRegistry
         )
     {

--- a/contracts/mocks/UpdatedDummyUsernameRegistrar.sol
+++ b/contracts/mocks/UpdatedDummyUsernameRegistrar.sol
@@ -11,18 +11,16 @@ contract UpdatedDummyUsernameRegistrar is DummyUsernameRegistrar {
         ENS _ensRegistry,
         PublicResolver _resolver,
         bytes32 _ensNode,
-        uint256 _usernameMinLength,
-        bytes32 _reservedUsernamesMerkleRoot,
+        address _slashMechanism,
         address _parentRegistry
     )
         public
-        DummyUsernameRegistrar(
+        UsernameRegistrar(
             _token,
             _ensRegistry,
             _resolver,
             _ensNode,
-            _usernameMinLength,
-            _reservedUsernamesMerkleRoot,
+            _slashMechanism,
             _parentRegistry
         )
     {

--- a/contracts/mocks/UpdatedDummyUsernameRegistrar.sol
+++ b/contracts/mocks/UpdatedDummyUsernameRegistrar.sol
@@ -15,7 +15,7 @@ contract UpdatedDummyUsernameRegistrar is DummyUsernameRegistrar {
         address _parentRegistry
     )
         public
-        UsernameRegistrar(
+        DummyUsernameRegistrar(
             _token,
             _ensRegistry,
             _resolver,

--- a/contracts/mocks/UpdatedUsernameRegistrar.sol
+++ b/contracts/mocks/UpdatedUsernameRegistrar.sol
@@ -11,8 +11,7 @@ contract UpdatedUsernameRegistrar is UsernameRegistrar {
         ENS _ensRegistry,
         PublicResolver _resolver,
         bytes32 _ensNode,
-        uint256 _usernameMinLength,
-        bytes32 _reservedUsernamesMerkleRoot,
+        address _slashMechanism,
         address _parentRegistry
     )
         public
@@ -21,8 +20,7 @@ contract UpdatedUsernameRegistrar is UsernameRegistrar {
             _ensRegistry,
             _resolver,
             _ensNode,
-            _usernameMinLength,
-            _reservedUsernamesMerkleRoot,
+            _slashMechanism,
             _parentRegistry
         )
     {

--- a/contracts/registry/SlashMechanism.sol
+++ b/contracts/registry/SlashMechanism.sol
@@ -17,7 +17,7 @@ contract SlashMechanism {
         UsernameRegistrar registrar;
     }
 
-    mapping (bytes32 => SlashReserve) reservedSlashers;
+    mapping (bytes32 => SlashReserve) public reservedSlashers;
     //Slashing conditions
     uint256 public usernameMinLength;
     bytes32 public reservedUsernamesMerkleRoot;

--- a/contracts/registry/SlashMechanism.sol
+++ b/contracts/registry/SlashMechanism.sol
@@ -32,7 +32,7 @@ contract SlashMechanism {
 
     /**
      * @notice secretly reserve the slashing reward to `msg.sender`
-     * @param _secret keccak256(abi.encodePacked(namehash, creationTime, reserveSecret)) 
+     * @param _secret keccak256(abi.encodePacked(label, reserveSecret)) 
      * @param _registrar address of the registrar with the offending name
      */
     function reserveSlash(UsernameRegistrar _registrar, bytes32 _secret) external {

--- a/contracts/registry/SlashMechanism.sol
+++ b/contracts/registry/SlashMechanism.sol
@@ -40,7 +40,7 @@ contract SlashMechanism {
         reservedSlashers[_secret] = SlashReserve(msg.sender, block.number, _registrar);
     }
 
-        /**
+    /**
      * @notice Slash username smaller then `usernameMinLength`.
      * @param _username Raw value of offending username.
      */

--- a/contracts/registry/SlashMechanism.sol
+++ b/contracts/registry/SlashMechanism.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: CC0-1.0
+
+pragma solidity 0.5.11;
+
+import "./UsernameRegistrar.sol";
+
+
+/** 
+ * @author Ricardo Guilherme Schmidt (Status Research & Development GmbH) 
+ * @notice Defines static rules for slashing usernames
+ */
+contract SlashMechanism {
+
+    struct SlashReserve {
+        address reserver;
+        uint256 blockNumber;
+        UsernameRegistrar registrar;
+    }
+
+    mapping (bytes32 => SlashReserve) reservedSlashers;
+    //Slashing conditions
+    uint256 public usernameMinLength;
+    bytes32 public reservedUsernamesMerkleRoot;
+
+    constructor(
+        uint256 _usernameMinLength,
+        bytes32 _reservedUsernamesMerkleRoot
+    ) public {
+        usernameMinLength = _usernameMinLength;
+        reservedUsernamesMerkleRoot = _reservedUsernamesMerkleRoot;
+    }
+
+    /**
+     * @notice secretly reserve the slashing reward to `msg.sender`
+     * @param _secret keccak256(abi.encodePacked(namehash, creationTime, reserveSecret)) 
+     * @param _registrar address of the registrar with the offending name
+     */
+    function reserveSlash(UsernameRegistrar _registrar, bytes32 _secret) external {
+        require(reservedSlashers[_secret].blockNumber == 0, "Already Reserved");
+        reservedSlashers[_secret] = SlashReserve(msg.sender, block.number);
+    }
+
+        /**
+     * @notice Slash username smaller then `usernameMinLength`.
+     * @param _username Raw value of offending username.
+     */
+    function slashSmallUsername(
+        string _username,
+        uint256 _reserveSecret
+    ) 
+        external 
+    {
+        bytes memory username = bytes(_username);
+        require(username.length < usernameMinLength, "Not a small username.");
+        slashUsername(username, _reserveSecret);
+    }
+
+    /**
+     * @notice Slash username starting with "0x" and with length greater than 12.
+     * @param _username Raw value of offending username.
+     */
+    function slashAddressLikeUsername(
+        string _username,
+        uint256 _reserveSecret
+    ) 
+        external 
+    {
+        bytes memory username = bytes(_username);
+        require(username.length > 12, "Too small to look like an address.");
+        require(username[0] == byte("0"), "First character need to be 0");
+        require(username[1] == byte("x"), "Second character need to be x");
+        for(uint i = 2; i < 7; i++){
+            byte b = username[i];
+            require((b >= 48 && b <= 57) || (b >= 97 && b <= 102), "Does not look like an address");
+        }
+        slashUsername(username, _reserveSecret);
+    }  
+
+    /**
+     * @notice Slash username that is exactly a reserved name.
+     * @param _username Raw value of offending username.
+     * @param _proof Merkle proof that name is listed on merkle tree.
+     */
+    function slashReservedUsername(
+        string _username,
+        bytes32[] _proof,
+        uint256 _reserveSecret
+    ) 
+        external 
+    {   
+        bytes memory username = bytes(_username);
+        require(
+            MerkleProof.verifyProof(
+                _proof,
+                reservedUsernamesMerkleRoot,
+                keccak256(username)
+            ),
+            "Invalid Proof."
+        );
+        slashUsername(username, _reserveSecret);
+    }
+
+    /**
+     * @notice Slash username that contains a non alphanumeric character.
+     * @param _username Raw value of offending username.
+     * @param _offendingPos Position of non alphanumeric character.
+     */
+    function slashInvalidUsername(
+        string _username,
+        uint256 _offendingPos,
+        uint256 _reserveSecret
+    ) 
+        external
+    { 
+        bytes memory username = bytes(_username);
+        require(username.length > _offendingPos, "Invalid position.");
+        byte b = username[_offendingPos];
+        
+        require(!((b >= 48 && b <= 57) || (b >= 97 && b <= 122)), "Not invalid character.");
+    
+        slashUsername(username, _reserveSecret);
+    }
+
+    function slashUsername(string _username, uint256 _reserveSecret) internal{
+        bytes32 secret = keccak256(abi.encodePacked(_username, _reserveSecret));
+        SlashReserve memory reserve = reservedSlashers[secret];
+        require(reserve.reserver != address(0), "Not reserved.");
+        require(reserve.blockNumber < block.number, "Cannot reveal in same block");
+        delete reservedSlashers[secret];
+        reserve.registrar.slashUsername(_username, reserve.reserver);
+    }
+} 

--- a/contracts/registry/SlashMechanism.sol
+++ b/contracts/registry/SlashMechanism.sol
@@ -32,8 +32,8 @@ contract SlashMechanism {
 
     /**
      * @notice secretly reserve the slashing reward to `msg.sender`
-     * @param _secret keccak256(abi.encodePacked(label, reserveSecret)) 
      * @param _registrar address of the registrar with the offending name
+     * @param _secret keccak256(abi.encodePacked(label, reserveSecret)), label being the username label and reserveSecret a random number.
      */
     function reserveSlash(UsernameRegistrar _registrar, bytes32 _secret) external {
         require(reservedSlashers[_secret].blockNumber == 0, "Already Reserved");
@@ -43,6 +43,7 @@ contract SlashMechanism {
     /**
      * @notice Slash username smaller then `usernameMinLength`.
      * @param _username Raw value of offending username.
+     * @param _reserveSecret number used in reserve secret generation.
      */
     function slashSmallUsername(
         string calldata _username,
@@ -58,6 +59,7 @@ contract SlashMechanism {
     /**
      * @notice Slash username starting with "0x" and with length greater than 12.
      * @param _username Raw value of offending username.
+     * @param _reserveSecret number used in reserve secret generation.
      */
     function slashAddressLikeUsername(
         string calldata _username,
@@ -80,6 +82,7 @@ contract SlashMechanism {
      * @notice Slash username that is exactly a reserved name.
      * @param _username Raw value of offending username.
      * @param _proof Merkle proof that name is listed on merkle tree.
+     * @param _reserveSecret number used in reserve secret generation.
      */
     function slashReservedUsername(
         string calldata _username,
@@ -104,6 +107,7 @@ contract SlashMechanism {
      * @notice Slash username that contains a non alphanumeric character.
      * @param _username Raw value of offending username.
      * @param _offendingPos Position of non alphanumeric character.
+     * @param _reserveSecret number used in reserve secret generation.
      */
     function slashInvalidUsername(
         string calldata _username,
@@ -121,6 +125,11 @@ contract SlashMechanism {
         slashUsername(_username, _reserveSecret);
     }
 
+    /**
+     * @dev Checks for reservation and requests username slashing in the selected registrar.
+     * @param _username Raw value of offending username.
+     * @param _reserveSecret number used in reserve secret generation.
+     */
     function slashUsername(string memory _username, uint256 _reserveSecret) internal{
         bytes32 secret = keccak256(abi.encodePacked(_username, _reserveSecret));
         SlashReserve memory reserve = reservedSlashers[secret];

--- a/contracts/registry/UsernameRegistrar.sol
+++ b/contracts/registry/UsernameRegistrar.sol
@@ -82,6 +82,7 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
         resolver = _resolver;
         ensNode = _ensNode;
         slashMechanism = _slashMechanism;
+        lastUpdate = block.timestamp;
         parentRegistry = _parentRegistry;
         setState(RegistrarState.Inactive);
     }
@@ -623,7 +624,7 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
 
         if (amountToTransfer > 0) {
             reserveAmount -= amountToTransfer;
-            if(lastUpdate > creationTime) {
+            if(lastUpdate < creationTime) {
                 uint256 partialDeposit = amountToTransfer / 3;
                 amountToTransfer = partialDeposit * 2; // reserve 1/3 to network (controller)
             }

--- a/contracts/registry/UsernameRegistrar.sol
+++ b/contracts/registry/UsernameRegistrar.sol
@@ -626,8 +626,7 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
         if (amountToTransfer > 0) {
             reserveAmount -= amountToTransfer;
             if(lastUpdate < creationTime) {
-                uint256 partialDeposit = amountToTransfer / 3;
-                amountToTransfer = partialDeposit * 2; // reserve 1/3 to network (controller)
+                amountToTransfer = (amountToTransfer * 2) / 3; // reserve 1/3 to network (controller)
             }
             require(token.transfer(beneficiary, amountToTransfer), "Error in transfer.");
         }

--- a/contracts/registry/UsernameRegistrar.sol
+++ b/contracts/registry/UsernameRegistrar.sol
@@ -265,6 +265,7 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
         onlyController
     {
         lastUpdate = block.timestamp;
+        require(_slashMechanism != address(0), "Zero address for _slashMechanism");
         slashMechanism = _slashMechanism;
     }
 

--- a/contracts/registry/UsernameRegistrar.sol
+++ b/contracts/registry/UsernameRegistrar.sol
@@ -60,8 +60,7 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
      * @param _ensRegistry Ethereum Name Service root contract address.
      * @param _resolver Public Resolver for resolving usernames.
      * @param _ensNode ENS node (domain) being used for usernames subnodes (subdomain)
-     * @param _usernameMinLength Minimum length of usernames
-     * @param _reservedUsernamesMerkleRoot Merkle root of reserved usernames
+     * @param _slashMechanism Slashing mechanism address
      * @param _parentRegistry Address of old registry (if any) for optional account migration.
      */
     constructor(
@@ -591,13 +590,13 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
      * @param _username Username being slashed.
      */
     function slashUsername(
-        bytes calldata _username,
+        string calldata _username,
         address _reserver
     ) 
         external 
     {
         require(msg.sender == slashMechanism, "Unauthorized");
-        bytes32 label = keccak256(_username);
+        bytes32 label = keccak256(bytes(_username));
         bytes32 namehash = keccak256(abi.encodePacked(ensNode, label));
         uint256 amountToTransfer = 0;
         uint256 creationTime = accounts[label].creationTime;

--- a/contracts/registry/UsernameRegistrar.sol
+++ b/contracts/registry/UsernameRegistrar.sol
@@ -22,12 +22,9 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
 
     uint256 public constant releaseDelay = 365 days;
     mapping (bytes32 => Account) public accounts;
-    mapping (bytes32 => SlashReserve) reservedSlashers;
 
-    //Slashing conditions
-    uint256 public usernameMinLength;
-    bytes32 public reservedUsernamesMerkleRoot;
-
+    address public slashMechanism;
+    
     event RegistryState(RegistrarState state);
     event RegistryPrice(uint256 price);
     event RegistryMoved(address newRegistry);
@@ -45,10 +42,7 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
         address owner;
     }
 
-    struct SlashReserve {
-        address reserver;
-        uint256 blockNumber;
-    }
+
 
     /**
      * @notice Callable only by `parentRegistry()` to continue migration of ENSSubdomainRegistry.
@@ -75,8 +69,7 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
         ENS _ensRegistry,
         PublicResolver _resolver,
         bytes32 _ensNode,
-        uint256 _usernameMinLength,
-        bytes32 _reservedUsernamesMerkleRoot,
+        address _slashMechanism,
         address _parentRegistry
     )
         public
@@ -89,8 +82,7 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
         ensRegistry = _ensRegistry;
         resolver = _resolver;
         ensNode = _ensNode;
-        usernameMinLength = _usernameMinLength;
-        reservedUsernamesMerkleRoot = _reservedUsernamesMerkleRoot;
+        slashMechanism = _slashMechanism;
         parentRegistry = _parentRegistry;
         setState(RegistrarState.Inactive);
     }
@@ -103,9 +95,7 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
      * - User deposits are completely protected. The contract controller cannot access them.
      * - User's address(es) will be publicly associated with the ENS name.
      * - User must authorise the contract to transfer `price` `token.name()`  on their behalf.
-     * - Usernames registered with less then `usernameMinLength` characters can be slashed.
-     * - Usernames contained in the merkle tree of root `reservedUsernamesMerkleRoot` can be slashed.
-     * - Usernames starting with `0x` and bigger then 12 characters can be slashed.
+     * - Usernames registered can be slashed if offending the `slashMechanism` contract rules.
      * - If terms of the contract change—e.g. Status makes contract upgrades—the user has the right to release the username and get their deposit back.
      * @param _label Choosen unowned username hash.
      * @param _account Optional address to set at public resolver.
@@ -186,95 +176,6 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
         emit UsernameOwner(namehash, msg.sender);
     }
 
-    /**
-     * @notice secretly reserve the slashing reward to `msg.sender`
-     * @param _secret keccak256(abi.encodePacked(namehash, creationTime, reserveSecret))
-     */
-    function reserveSlash(bytes32 _secret) external {
-        require(reservedSlashers[_secret].blockNumber == 0, "Already Reserved");
-        reservedSlashers[_secret] = SlashReserve(msg.sender, block.number);
-    }
-
-    /**
-     * @notice Slash username smaller then `usernameMinLength`.
-     * @param _username Raw value of offending username.
-     */
-    function slashSmallUsername(
-        string calldata _username,
-        uint256 _reserveSecret
-    )
-        external
-    {
-        bytes memory username = bytes(_username);
-        require(username.length < usernameMinLength, "Not a small username.");
-        slashUsername(username, _reserveSecret);
-    }
-
-    /**
-     * @notice Slash username starting with "0x" and with length greater than 12.
-     * @param _username Raw value of offending username.
-     */
-    function slashAddressLikeUsername(
-        string calldata _username,
-        uint256 _reserveSecret
-    )
-        external
-    {
-        bytes memory username = bytes(_username);
-        require(username.length > 12, "Too small to look like an address.");
-        require(username[0] == byte("0"), "First character need to be 0");
-        require(username[1] == byte("x"), "Second character need to be x");
-        for(uint i = 2; i < 7; i++){
-            byte b = username[i];
-            require((b >= 0x30 && b <= 0x39) || (b >= 0x61 && b <= 0x66), "Does not look like an address");
-        }
-        slashUsername(username, _reserveSecret);
-    }
-
-    /**
-     * @notice Slash username that is exactly a reserved name.
-     * @param _username Raw value of offending username.
-     * @param _proof Merkle proof that name is listed on merkle tree.
-     */
-    function slashReservedUsername(
-        string calldata _username,
-        bytes32[] calldata _proof,
-        uint256 _reserveSecret
-    )
-        external
-    {
-        bytes memory username = bytes(_username);
-        require(
-            MerkleProof.verifyProof(
-                _proof,
-                reservedUsernamesMerkleRoot,
-                keccak256(username)
-            ),
-            "Invalid Proof."
-        );
-        slashUsername(username, _reserveSecret);
-    }
-
-    /**
-     * @notice Slash username that contains a non alphanumeric character.
-     * @param _username Raw value of offending username.
-     * @param _offendingPos Position of non alphanumeric character.
-     */
-    function slashInvalidUsername(
-        string calldata _username,
-        uint256 _offendingPos,
-        uint256 _reserveSecret
-    )
-        external
-    {
-        bytes memory username = bytes(_username);
-        require(username.length > _offendingPos, "Invalid position.");
-        byte b = username[_offendingPos];
-
-        require(!((b >= 0x30 && b <= 0x39) || (b >= 0x61 && b <= 0x7A)), "Not invalid character.");
-
-        slashUsername(username, _reserveSecret);
-    }
 
     /**
      * @notice Clear resolver and ownership of unowned subdomians.
@@ -676,11 +577,12 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
      * @param _username Username being slashed.
      */
     function slashUsername(
-        bytes memory _username,
-        uint256 _reserveSecret
-    )
-        internal
+        bytes calldata _username,
+        address _reserver
+    ) 
+        external 
     {
+        require(msg.sender == slashMechanism, "Unauthorized");
         bytes32 label = keccak256(_username);
         bytes32 namehash = keccak256(abi.encodePacked(ensNode, label));
         uint256 amountToTransfer = 0;
@@ -706,13 +608,7 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
             reserveAmount -= amountToTransfer;
             uint256 partialDeposit = amountToTransfer / 3;
             amountToTransfer = partialDeposit * 2; // reserve 1/3 to network (controller)
-            bytes32 secret = keccak256(abi.encodePacked(namehash, creationTime, _reserveSecret));
-            SlashReserve memory reserve = reservedSlashers[secret];
-            require(reserve.reserver != address(0), "Not reserved.");
-            require(reserve.blockNumber < block.number, "Cannot reveal in same block");
-            delete reservedSlashers[secret];
-
-            require(token.transfer(reserve.reserver, amountToTransfer), "Error in transfer.");
+            require(token.transfer(_reserver, amountToTransfer), "Error in transfer.");
         }
         emit UsernameOwner(namehash, address(0));
     }

--- a/contracts/registry/UsernameRegistrar.sol
+++ b/contracts/registry/UsernameRegistrar.sol
@@ -2,7 +2,6 @@
 
 pragma solidity 0.5.11;
 
-import "../common/MerkleProof.sol";
 import "../common/Controlled.sol";
 import "../token/ERC20Token.sol";
 import "../token/ApproveAndCallFallBack.sol";

--- a/contracts/registry/UsernameRegistrar.sol
+++ b/contracts/registry/UsernameRegistrar.sol
@@ -254,6 +254,19 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
         resolver = PublicResolver(_resolver);
     }
 
+    /** 
+     * @notice Updates slash mechanism.
+     * @param _slashMechanism New Slash Mechanism
+     */
+    function setSlashMechanism(
+        address _slashMechanism
+    ) 
+        external
+        onlyController
+    {
+        slashMechanism = _slashMechanism;
+    }
+
     /**
      * @notice Updates registration price.
      * @param _price New registration price.

--- a/contracts/registry/UsernameRegistrar.sol
+++ b/contracts/registry/UsernameRegistrar.sol
@@ -131,7 +131,7 @@ contract UsernameRegistrar is Controlled, ApproveAndCallFallBack {
         require(account.creationTime > 0, "Username not registered.");
         if (state == RegistrarState.Active) {
             require(msg.sender == ensRegistry.owner(namehash), "Not owner of ENS node.");
-            require(block.timestamp > account.creationTime + releaseDelay, "Release period not reached.");
+            require(block.timestamp > account.creationTime + releaseDelay || lastUpdate > account.creationTime, "Release period not reached.");
         } else {
             require(msg.sender == account.owner, "Not the former account owner.");
         }

--- a/test/usernameregistrar.spec.js
+++ b/test/usernameregistrar.spec.js
@@ -909,7 +909,7 @@ contract('UsernameRegistrar', function () {
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), utils.zeroAddress);
     });
     
-    it('should slash a username of a not migrated subnode that became unallowed', async () => {
+    it('should return funds of slashing when changed rules', async () => {
       const registrant = accountsArr[5];
       const notRegistrant = accountsArr[6];
 
@@ -931,7 +931,7 @@ contract('UsernameRegistrar', function () {
       const initialRegistryBalance = +await TestToken.methods.balanceOf(Dummy2UsernameRegistrar.address).call();
 
       
-      await Dummy2UsernameRegistrar.methods.moveRegistry(UpdatedDummy2UsernameRegistrar.address).send();
+      await Dummy2UsernameRegistrar.methods.setSlashMechanism(SlashMechanism.address).send();
 
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant, "ENSRegistry owner mismatch");
       assert.equal(await ENSRegistry.methods.resolver(usernameHash).call(), PublicResolver.address, "Resolver wrongly defined");

--- a/test/usernameregistrar.spec.js
+++ b/test/usernameregistrar.spec.js
@@ -38,95 +38,99 @@ const merkleRoot = merkleTree.getHexRoot();
 let accountsArr;
 config(
   {
-    contracts: {
-      deploy: {      
-        "TestToken": { },
-        "ENSRegistry": {
-          "onDeploy": [
-            "await ENSRegistry.methods.setSubnodeOwner('0x0000000000000000000000000000000000000000000000000000000000000000', '0x4f5b812789fc606be1b3b16908db13fc7a9adf7ca72641f84d75b47069d3d7f0', web3.eth.defaultAccount).send()"
-          ]
-        },
-        "PublicResolver": {
-          "args": [
-            "$ENSRegistry"
-          ]
-        },
-        "UsernameRegistrar": {
-          "args": [
-            "$TestToken",
-            "$ENSRegistry",
-            "$PublicResolver",
-            registry.namehash,
-            "3", 
-            merkleRoot,
-            "0x0000000000000000000000000000000000000000"
-          ],
-          "onDeploy": [
-            "await ENSRegistry.methods.setSubnodeOwner('0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae', '"+registry.label+"', UsernameRegistrar.address).send()",
-          ]
-        },
-        "UpdatedUsernameRegistrar": {
-          "args": [
-            "$TestToken",
-            "$ENSRegistry",
-            "$PublicResolver",
-            registry.namehash,
-            "3", 
-            merkleRoot,
-            "$UsernameRegistrar"
-          ]
-        },
-        "DummyUsernameRegistrar": {
-          "args": [
-            "$TestToken",
-            "$ENSRegistry",
-            "$PublicResolver",
-            dummyRegistry.namehash,
-            "3", 
-            merkleRoot,
-            "0x0000000000000000000000000000000000000000"
-          ],
-          "onDeploy": [
-            "await ENSRegistry.methods.setSubnodeOwner('0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae', '"+dummyRegistry.label+"', DummyUsernameRegistrar.address).send()",
-          ]
-        },
-        "UpdatedDummyUsernameRegistrar": {
-          "args": [
-            "$TestToken",
-            "$ENSRegistry",
-            "$PublicResolver",
-            dummyRegistry.namehash,
-            "3", 
-            merkleRoot,
-            "$DummyUsernameRegistrar"
-          ]
-        },
-        "Dummy2UsernameRegistrar": {
-          "args": [
-            "$TestToken",
-            "$ENSRegistry",
-            "$PublicResolver",
-            dummy2Registry.namehash,
-            "3", 
-            utils.zeroBytes32,
-            "0x0000000000000000000000000000000000000000"
-          ],
-          "onDeploy": [
-            "await ENSRegistry.methods.setSubnodeOwner('0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae', '"+dummy2Registry.label+"', Dummy2UsernameRegistrar.address).send()",
-            "await Dummy2UsernameRegistrar.methods.activate("+dummy2Registry.price+").send()"
-          ]
-        },
-        "UpdatedDummy2UsernameRegistrar": {
-          "args": [
-            "$TestToken",
-            "$ENSRegistry",
-            "$PublicResolver",
-            dummy2Registry.namehash,
-            "3", 
-            merkleRoot,
-            "$Dummy2UsernameRegistrar"
-          ]
-        }
+    contracts: {        
+      "TestToken": { },
+      "ENSRegistry": {
+        "onDeploy": [
+          "await ENSRegistry.methods.setSubnodeOwner('0x0000000000000000000000000000000000000000000000000000000000000000', '0x4f5b812789fc606be1b3b16908db13fc7a9adf7ca72641f84d75b47069d3d7f0', web3.eth.defaultAccount).send()"
+        ]
+      },
+      "PublicResolver": {
+        "args": [
+          "$ENSRegistry"
+        ]
+      },
+      "SlashMechanism": {
+        "args": [
+          "3", 
+          merkleRoot
+        ],
+      }
+      ,"UsernameRegistrar": {
+        "args": [
+          "$TestToken",
+          "$ENSRegistry",
+          "$PublicResolver",
+          registry.namehash,
+          "$SlashMechanism",
+          "0x0000000000000000000000000000000000000000"
+        ],
+        "onDeploy": [
+          "await ENSRegistry.methods.setSubnodeOwner('0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae', '"+registry.label+"', UsernameRegistrar.address).send()",
+        ]
+      },
+      "UpdatedUsernameRegistrar": {
+        "args": [
+          "$TestToken",
+          "$ENSRegistry",
+          "$PublicResolver",
+          registry.namehash,
+          "$SlashMechanism",
+          "$UsernameRegistrar"
+        ]
+      },
+      "DummyUsernameRegistrar": {
+        "args": [
+          "$TestToken",
+          "$ENSRegistry",
+          "$PublicResolver",
+          dummyRegistry.namehash,
+          "$SlashMechanism",
+          "0x0"
+        ],
+        "onDeploy": [
+          "await ENSRegistry.methods.setSubnodeOwner('0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae', '"+dummyRegistry.label+"', DummyUsernameRegistrar.address).send()",
+        ]
+      },
+      "UpdatedDummyUsernameRegistrar": {
+        "args": [
+          "$TestToken",
+          "$ENSRegistry",
+          "$PublicResolver",
+          dummyRegistry.namehash,
+          "$SlashMechanism",
+          "$DummyUsernameRegistrar"
+        ]
+      },
+      "Dummy2SlashMechanism": {
+        "args": [
+          "3", 
+          utils.zeroBytes32
+        ],
+      },
+      "Dummy2UsernameRegistrar": {
+        "args": [
+          "$TestToken",
+          "$ENSRegistry",
+          "$PublicResolver",
+          dummy2Registry.namehash,
+          "$Dummy2SlashMechanism",
+          "0x0000000000000000000000000000000000000000"
+        ],
+        "onDeploy": [
+          "await ENSRegistry.methods.setSubnodeOwner('0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae', '"+dummy2Registry.label+"', Dummy2UsernameRegistrar.address).send()",
+          "await Dummy2UsernameRegistrar.methods.activate("+dummy2Registry.price+").send()"
+        ]
+      },
+      "UpdatedDummy2UsernameRegistrar": {
+        "args": [
+          "$TestToken",
+          "$ENSRegistry",
+          "$PublicResolver",
+          dummy2Registry.namehash,
+          "$SlashMechanism",
+          "$Dummy2UsernameRegistrar"
+        ]
       }
     }
   }, (_err, web3_accounts) => {
@@ -143,6 +147,8 @@ const DummyUsernameRegistrar = artifacts.require('DummyUsernameRegistrar');
 const UpdatedDummyUsernameRegistrar = artifacts.require('UpdatedDummyUsernameRegistrar');
 const Dummy2UsernameRegistrar = artifacts.require('Dummy2UsernameRegistrar');
 const UpdatedDummy2UsernameRegistrar = artifacts.require('UpdatedDummy2UsernameRegistrar');
+const SlashMechanism = artifacts.require('SlashMechanism');
+const Dummy2SlashMechanism = artifacts.require('Dummy2SlashMechanism');
 
 contract('UsernameRegistrar', function () {
 
@@ -605,9 +611,9 @@ contract('UsernameRegistrar', function () {
       assert.notEqual(+await UsernameRegistrar.methods.getCreationTime(label).call(), 0);
       const creationTime = await UsernameRegistrar.methods.getCreationTime(web3Utils.sha3(username)).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send();
-      await UsernameRegistrar.methods.slashInvalidUsername(username, 4, reserveSecret).send()
+      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
+      await SlashMechanism.methods.slashInvalidUsername(username, 4, reserveSecret).send()
       //TODO: check events
       assert.equal(+await UsernameRegistrar.methods.getCreationTime(label).call(), 0);
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), utils.zeroAddress);
@@ -627,11 +633,10 @@ contract('UsernameRegistrar', function () {
       await utils.increaseTime(20000)   
       const creationTime = await UsernameRegistrar.methods.getCreationTime(web3Utils.sha3(username)).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send();
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
       let failed;
       try{
-        await UsernameRegistrar.methods.slashInvalidUsername(username, 4, reserveSecret).send()
+        await SlashMechanism.methods.slashInvalidUsername(username, 4, reserveSecret).send()
         failed = false;
       } catch(e){
         failed = true;
@@ -657,11 +662,11 @@ contract('UsernameRegistrar', function () {
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
       const creationTime = await UsernameRegistrar.methods.getCreationTime(web3Utils.sha3(username)).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send();
+      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
       let failed;
       try{
-        await UsernameRegistrar.methods.slashReservedUsername(username, merkleTree.getHexProof(ReservedUsernames[0]), reserveSecret).send()
+        await SlashMechanism.methods.slashReservedUsername(username, merkleTree.getHexProof(ReservedUsernames[0]), reserveSecret).send()
         failed = false;
       } catch(e){
         failed = true;
@@ -684,11 +689,11 @@ contract('UsernameRegistrar', function () {
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
       const creationTime = await UsernameRegistrar.methods.getCreationTime(web3Utils.sha3(username)).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send();
+      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
       let failed;
       try{
-        await UsernameRegistrar.methods.slashReservedUsername(username, merkleTree.getHexProof(ReservedUsernames[1]), reserveSecret).send()
+        await SlashMechanism.methods.slashReservedUsername(username, merkleTree.getHexProof(ReservedUsernames[1]), reserveSecret).send()
         failed = false;
       } catch(e){
         failed = true;
@@ -711,9 +716,9 @@ contract('UsernameRegistrar', function () {
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
       const creationTime = await UsernameRegistrar.methods.getCreationTime(web3Utils.sha3(username)).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send();
-      result = await UsernameRegistrar.methods.slashReservedUsername(username, merkleTree.getHexProof(username), reserveSecret).send()  
+      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
+      await SlashMechanism.methods.slashReservedUsername(username, merkleTree.getHexProof(username), reserveSecret).send()  
       //TODO: check events
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), utils.zeroAddress);
     });
@@ -735,11 +740,11 @@ contract('UsernameRegistrar', function () {
       await utils.increaseTime(1000)
       const creationTime = await UsernameRegistrar.methods.getCreationTime(web3Utils.sha3(username)).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send();
+      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
       let failed;
       try{
-        await UsernameRegistrar.methods.slashSmallUsername(username).send()    
+        await SlashMechanism.methods.slashSmallUsername(username).send()    
         failed = false;
       } catch(e){
         failed = true;
@@ -809,11 +814,11 @@ contract('UsernameRegistrar', function () {
       await utils.increaseTime(20000)
       const creationTime = await UsernameRegistrar.methods.getCreationTime(userlabelHash).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send();
+      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
       let failed;
       try{
-        result = await UsernameRegistrar.methods.slashAddressLikeUsername(username, reserveSecret).send()    
+        await SlashMechanism.methods.slashAddressLikeUsername(username, reserveSecret).send()    
         failed = false;
       } catch(e){
         failed = true;
@@ -836,11 +841,11 @@ contract('UsernameRegistrar', function () {
       await utils.increaseTime(20000)
       const creationTime = await UsernameRegistrar.methods.getCreationTime(userlabelHash).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send();
+      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
       let failed;
       try{
-        await UsernameRegistrar.methods.slashAddressLikeUsername(username, reserveSecret).send()    
+        await SlashMechanism.methods.slashAddressLikeUsername(username, reserveSecret).send()    
         failed = false;
       } catch(e){
         failed = true;
@@ -863,11 +868,11 @@ contract('UsernameRegistrar', function () {
       await utils.increaseTime(20000)
       const creationTime = await UsernameRegistrar.methods.getCreationTime(userlabelHash).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send();
+      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
       let failed;
       try{
-        await UsernameRegistrar.methods.slashAddressLikeUsername(username, reserveSecret).send()    
+        await SlashMechanism.methods.slashAddressLikeUsername(username, reserveSecret).send()    
         failed = false;
       } catch(e){
         failed = true;
@@ -896,9 +901,9 @@ contract('UsernameRegistrar', function () {
       const initialSlasherBalance = +await TestToken.methods.balanceOf(slasher).call();
       const creationTime = await UsernameRegistrar.methods.getCreationTime(label).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send({from: slasher});
-      await UsernameRegistrar.methods.slashSmallUsername(username, reserveSecret).send({from: slasher})
+      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
+      await SlashMechanism.methods.slashSmallUsername(username, reserveSecret).send({from: slasher})
       //TODO: check events
       assert.equal(+await TestToken.methods.balanceOf(slasher).call(), (+initialSlasherBalance)+((+partReward)*2));    
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), utils.zeroAddress);
@@ -933,9 +938,9 @@ contract('UsernameRegistrar', function () {
       assert.equal(await PublicResolver.methods.addr(usernameHash).call(), registrant, "Resolved address not set");      
       const creationTime = await UsernameRegistrar.methods.getCreationTime(label).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send({from: notRegistrant});
-      const resultRelease = await UpdatedDummy2UsernameRegistrar.methods.slashReservedUsername(
+      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      await SlashMechanism.methods.reserveSlash(UpdatedDummy2UsernameRegistrar.address, secret).send();
+      await SlashMechanism.methods.slashReservedUsername(
         username, 
         merkleTree.getHexProof(username),
         reserveSecret
@@ -970,9 +975,9 @@ contract('UsernameRegistrar', function () {
       const initialSlashReserverBalance = +await TestToken.methods.balanceOf(slashReserverCaller).call();
       const creationTime = await UsernameRegistrar.methods.getCreationTime(label).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send({from: slashReserverCaller});
-      await UsernameRegistrar.methods.slashSmallUsername(username, reserveSecret).send({from: slashReserverCaller})
+      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send({from: slashReserverCaller});
+      await SlashMechanism.methods.slashSmallUsername(username, reserveSecret).send({from: slashReserverCaller})
       //TODO: check events
       assert.equal(+await TestToken.methods.balanceOf(slashReserverCaller).call(), (+initialSlashReserverBalance)+(+partReward*2));    
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), utils.zeroAddress);

--- a/test/usernameregistrar.spec.js
+++ b/test/usernameregistrar.spec.js
@@ -39,98 +39,100 @@ let accountsArr;
 config(
   {
     contracts: {        
-      "TestToken": { },
-      "ENSRegistry": {
-        "onDeploy": [
-          "await ENSRegistry.methods.setSubnodeOwner('0x0000000000000000000000000000000000000000000000000000000000000000', '0x4f5b812789fc606be1b3b16908db13fc7a9adf7ca72641f84d75b47069d3d7f0', web3.eth.defaultAccount).send()"
-        ]
-      },
-      "PublicResolver": {
-        "args": [
-          "$ENSRegistry"
-        ]
-      },
-      "SlashMechanism": {
-        "args": [
-          "3", 
-          merkleRoot
-        ],
-      }
-      ,"UsernameRegistrar": {
-        "args": [
-          "$TestToken",
-          "$ENSRegistry",
-          "$PublicResolver",
-          registry.namehash,
-          "$SlashMechanism",
-          "0x0000000000000000000000000000000000000000"
-        ],
-        "onDeploy": [
-          "await ENSRegistry.methods.setSubnodeOwner('0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae', '"+registry.label+"', UsernameRegistrar.address).send()",
-        ]
-      },
-      "UpdatedUsernameRegistrar": {
-        "args": [
-          "$TestToken",
-          "$ENSRegistry",
-          "$PublicResolver",
-          registry.namehash,
-          "$SlashMechanism",
-          "$UsernameRegistrar"
-        ]
-      },
-      "DummyUsernameRegistrar": {
-        "args": [
-          "$TestToken",
-          "$ENSRegistry",
-          "$PublicResolver",
-          dummyRegistry.namehash,
-          "$SlashMechanism",
-          "0x0000000000000000000000000000000000000000"
-        ],
-        "onDeploy": [
-          "await ENSRegistry.methods.setSubnodeOwner('0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae', '"+dummyRegistry.label+"', DummyUsernameRegistrar.address).send()",
-        ]
-      },
-      "UpdatedDummyUsernameRegistrar": {
-        "args": [
-          "$TestToken",
-          "$ENSRegistry",
-          "$PublicResolver",
-          dummyRegistry.namehash,
-          "$SlashMechanism",
-          "$DummyUsernameRegistrar"
-        ]
-      },
-      "Dummy2SlashMechanism": {
-        "args": [
-          "3", 
-          utils.zeroBytes32
-        ],
-      },
-      "Dummy2UsernameRegistrar": {
-        "args": [
-          "$TestToken",
-          "$ENSRegistry",
-          "$PublicResolver",
-          dummy2Registry.namehash,
-          "$Dummy2SlashMechanism",
-          "0x0000000000000000000000000000000000000000"
-        ],
-        "onDeploy": [
-          "await ENSRegistry.methods.setSubnodeOwner('0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae', '"+dummy2Registry.label+"', Dummy2UsernameRegistrar.address).send()",
-          "await Dummy2UsernameRegistrar.methods.activate("+dummy2Registry.price+").send()"
-        ]
-      },
-      "UpdatedDummy2UsernameRegistrar": {
-        "args": [
-          "$TestToken",
-          "$ENSRegistry",
-          "$PublicResolver",
-          dummy2Registry.namehash,
-          "$SlashMechanism",
-          "$Dummy2UsernameRegistrar"
-        ]
+      deploy: {    
+        "TestToken": { },
+        "ENSRegistry": {
+          "onDeploy": [
+            "await ENSRegistry.methods.setSubnodeOwner('0x0000000000000000000000000000000000000000000000000000000000000000', '0x4f5b812789fc606be1b3b16908db13fc7a9adf7ca72641f84d75b47069d3d7f0', web3.eth.defaultAccount).send()"
+          ]
+        },
+        "PublicResolver": {
+          "args": [
+            "$ENSRegistry"
+          ]
+        },
+        "SlashMechanism": {
+          "args": [
+            "3", 
+            merkleRoot
+          ],
+        }
+        ,"UsernameRegistrar": {
+          "args": [
+            "$TestToken",
+            "$ENSRegistry",
+            "$PublicResolver",
+            registry.namehash,
+            "$SlashMechanism",
+            "0x0000000000000000000000000000000000000000"
+          ],
+          "onDeploy": [
+            "await ENSRegistry.methods.setSubnodeOwner('0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae', '"+registry.label+"', UsernameRegistrar.address).send()",
+          ]
+        },
+        "UpdatedUsernameRegistrar": {
+          "args": [
+            "$TestToken",
+            "$ENSRegistry",
+            "$PublicResolver",
+            registry.namehash,
+            "$SlashMechanism",
+            "$UsernameRegistrar"
+          ]
+        },
+        "DummyUsernameRegistrar": {
+          "args": [
+            "$TestToken",
+            "$ENSRegistry",
+            "$PublicResolver",
+            dummyRegistry.namehash,
+            "$SlashMechanism",
+            "0x0000000000000000000000000000000000000000"
+          ],
+          "onDeploy": [
+            "await ENSRegistry.methods.setSubnodeOwner('0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae', '"+dummyRegistry.label+"', DummyUsernameRegistrar.address).send()",
+          ]
+        },
+        "UpdatedDummyUsernameRegistrar": {
+          "args": [
+            "$TestToken",
+            "$ENSRegistry",
+            "$PublicResolver",
+            dummyRegistry.namehash,
+            "$SlashMechanism",
+            "$DummyUsernameRegistrar"
+          ]
+        },
+        "Dummy2SlashMechanism": {
+          "args": [
+            "3", 
+            utils.zeroBytes32
+          ],
+        },
+        "Dummy2UsernameRegistrar": {
+          "args": [
+            "$TestToken",
+            "$ENSRegistry",
+            "$PublicResolver",
+            dummy2Registry.namehash,
+            "$Dummy2SlashMechanism",
+            "0x0000000000000000000000000000000000000000"
+          ],
+          "onDeploy": [
+            "await ENSRegistry.methods.setSubnodeOwner('0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae', '"+dummy2Registry.label+"', Dummy2UsernameRegistrar.address).send()",
+            "await Dummy2UsernameRegistrar.methods.activate("+dummy2Registry.price+").send()"
+          ]
+        },
+        "UpdatedDummy2UsernameRegistrar": {
+          "args": [
+            "$TestToken",
+            "$ENSRegistry",
+            "$PublicResolver",
+            dummy2Registry.namehash,
+            "$SlashMechanism",
+            "$Dummy2UsernameRegistrar"
+          ]
+        }
       }
     }
   }, (_err, web3_accounts) => {
@@ -609,7 +611,6 @@ contract('UsernameRegistrar', function () {
       await utils.increaseTime(20000)
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
       assert.notEqual(+await UsernameRegistrar.methods.getCreationTime(label).call(), 0);
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(web3Utils.sha3(username)).call();
       const reserveSecret = 1337;
       const secret = web3Utils.soliditySha3(username, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
@@ -631,8 +632,8 @@ contract('UsernameRegistrar', function () {
         utils.zeroBytes32
       ).send({from: registrant}); 
       await utils.increaseTime(20000)   
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(web3Utils.sha3(username)).call();
       const reserveSecret = 1337;
+      const secret = web3Utils.soliditySha3(username, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
       let failed;
       try{
@@ -660,7 +661,6 @@ contract('UsernameRegistrar', function () {
       ).send({from: registrant});
       await utils.increaseTime(20000)
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(web3Utils.sha3(username)).call();
       const reserveSecret = 1337;
       const secret = web3Utils.soliditySha3(username, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
@@ -687,7 +687,6 @@ contract('UsernameRegistrar', function () {
       ).send({from: registrant});
       await utils.increaseTime(20000)
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(web3Utils.sha3(username)).call();
       const reserveSecret = 1337;
       const secret = web3Utils.soliditySha3(username, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
@@ -714,7 +713,6 @@ contract('UsernameRegistrar', function () {
       ).send({from: registrant});
       await utils.increaseTime(20000)
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(web3Utils.sha3(username)).call();
       const reserveSecret = 1337;
       const secret = web3Utils.soliditySha3(username, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
@@ -738,7 +736,6 @@ contract('UsernameRegistrar', function () {
         utils.zeroBytes32
       ).send({from: registrant});
       await utils.increaseTime(1000)
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(web3Utils.sha3(username)).call();
       const reserveSecret = 1337;
       const secret = web3Utils.soliditySha3(username, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
@@ -766,11 +763,10 @@ contract('UsernameRegistrar', function () {
       ).send({from: registrant});  
       await utils.increaseTime(20000)
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(web3Utils.sha3(username)).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send();
-      result = await UsernameRegistrar.methods.slashSmallUsername(username, reserveSecret).send()    
+      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
+      result = await SlashMechanism.methods.slashSmallUsername(username, reserveSecret).send()    
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), utils.zeroAddress);
     });
   });
@@ -791,11 +787,10 @@ contract('UsernameRegistrar', function () {
       ).send({from: registrant});
       await utils.increaseTime(1000)
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(userlabelHash).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(usernameHash, creationTime, reserveSecret);
-      await UsernameRegistrar.methods.reserveSlash(secret).send();
-      result = await UsernameRegistrar.methods.slashAddressLikeUsername(username, reserveSecret).send()    
+      const secret = web3Utils.soliditySha3({value: username, type: "string"}, reserveSecret);
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
+      result = await SlashMechanism.methods.slashAddressLikeUsername(username, reserveSecret).send()    
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), utils.zeroAddress);
     });
     it('should not slash username that starts with 0x but is smaller then 12', async () => {
@@ -812,9 +807,8 @@ contract('UsernameRegistrar', function () {
         utils.zeroBytes32
       ).send({from: registrant});
       await utils.increaseTime(20000)
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(userlabelHash).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      const secret = web3Utils.soliditySha3({value: username, type: "string"}, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
       let failed;
       try{
@@ -839,9 +833,8 @@ contract('UsernameRegistrar', function () {
         utils.zeroBytes32
       ).send({from: registrant});
       await utils.increaseTime(20000)
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(userlabelHash).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      const secret = web3Utils.soliditySha3({value: username, type: "string"}, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
       let failed;
       try{
@@ -866,9 +859,8 @@ contract('UsernameRegistrar', function () {
         utils.zeroBytes32
       ).send({from: registrant});
       await utils.increaseTime(20000)
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(userlabelHash).call();
       const reserveSecret = 1337;
-      const secret = web3Utils.soliditySha3(username, reserveSecret);
+      const secret = web3Utils.soliditySha3({value: username, type: "string"}, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
       let failed;
       try{
@@ -899,10 +891,9 @@ contract('UsernameRegistrar', function () {
       const partReward = await UsernameRegistrar.methods.getSlashRewardPart(label).call();
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
       const initialSlasherBalance = +await TestToken.methods.balanceOf(slasher).call();
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(label).call();
       const reserveSecret = 1337;
       const secret = web3Utils.soliditySha3(username, reserveSecret);
-      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
+      await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send({from: slasher});
       await SlashMechanism.methods.slashSmallUsername(username, reserveSecret).send({from: slasher})
       //TODO: check events
       assert.equal(+await TestToken.methods.balanceOf(slasher).call(), (+initialSlasherBalance)+((+partReward)*2));    
@@ -936,10 +927,9 @@ contract('UsernameRegistrar', function () {
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant, "ENSRegistry owner mismatch");
       assert.equal(await ENSRegistry.methods.resolver(usernameHash).call(), PublicResolver.address, "Resolver wrongly defined");
       assert.equal(await PublicResolver.methods.addr(usernameHash).call(), registrant, "Resolved address not set");      
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(label).call();
       const reserveSecret = 1337;
       const secret = web3Utils.soliditySha3(username, reserveSecret);
-      await SlashMechanism.methods.reserveSlash(UpdatedDummy2UsernameRegistrar.address, secret).send();
+      await SlashMechanism.methods.reserveSlash(Dummy2UsernameRegistrar.address, secret).send({from: notRegistrant});
       await SlashMechanism.methods.slashReservedUsername(
         username, 
         merkleTree.getHexProof(username),
@@ -973,7 +963,6 @@ contract('UsernameRegistrar', function () {
       assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
       const partReward = await UsernameRegistrar.methods.getSlashRewardPart(label).call();
       const initialSlashReserverBalance = +await TestToken.methods.balanceOf(slashReserverCaller).call();
-      const creationTime = await UsernameRegistrar.methods.getCreationTime(label).call();
       const reserveSecret = 1337;
       const secret = web3Utils.soliditySha3(username, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send({from: slashReserverCaller});

--- a/test/usernameregistrar.spec.js
+++ b/test/usernameregistrar.spec.js
@@ -86,7 +86,7 @@ config(
           "$PublicResolver",
           dummyRegistry.namehash,
           "$SlashMechanism",
-          "0x0"
+          "0x0000000000000000000000000000000000000000"
         ],
         "onDeploy": [
           "await ENSRegistry.methods.setSubnodeOwner('0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae', '"+dummyRegistry.label+"', DummyUsernameRegistrar.address).send()",

--- a/test/usernameregistrar.spec.js
+++ b/test/usernameregistrar.spec.js
@@ -736,6 +736,7 @@ contract('UsernameRegistrar', function () {
         utils.zeroBytes32
       ).send({from: registrant});
       await utils.increaseTime(1000)
+      assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
       const reserveSecret = 1337;
       const secret = web3Utils.soliditySha3(username, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
@@ -807,6 +808,7 @@ contract('UsernameRegistrar', function () {
         utils.zeroBytes32
       ).send({from: registrant});
       await utils.increaseTime(20000)
+      assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
       const reserveSecret = 1337;
       const secret = web3Utils.soliditySha3({value: username, type: "string"}, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
@@ -833,6 +835,7 @@ contract('UsernameRegistrar', function () {
         utils.zeroBytes32
       ).send({from: registrant});
       await utils.increaseTime(20000)
+      assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
       const reserveSecret = 1337;
       const secret = web3Utils.soliditySha3({value: username, type: "string"}, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();
@@ -859,6 +862,7 @@ contract('UsernameRegistrar', function () {
         utils.zeroBytes32
       ).send({from: registrant});
       await utils.increaseTime(20000)
+      assert.equal(await ENSRegistry.methods.owner(usernameHash).call(), registrant);
       const reserveSecret = 1337;
       const secret = web3Utils.soliditySha3({value: username, type: "string"}, reserveSecret);
       await SlashMechanism.methods.reserveSlash(UsernameRegistrar.address, secret).send();


### PR DESCRIPTION
Fixes #105

With this PR we make rules for slash mechanism in a separate contract, which can be more easily maintained, audited and replaced. 

This change will allow Status to replace the rules for "Invalid/Reserved Usernames" without changing the ENS Usernames address.

TODO LIST: 
- [x] Separate Slash Mechanism to a dedicated contract; (a5f7f8e)
- [x] Allow controller to update the Slash Mechanism Address; (612c063)
- [x] Returns funds to registrant when usernames does not offend former slash mechanism but offends the updated slash mechanism;  (6a2acce)
- [x] Allow instant release of names if Slash Mechanism is changed. (31a1a9d)